### PR TITLE
trailingAnchor,bottomAnchorの元とequalToを逆にした

### DIFF
--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -19,9 +19,9 @@ EXTERNAL SOURCES:
     :path: "./../"
 
 SPEC CHECKSUMS:
-  ImageViewer.swift: 5a7de1366351c307023daf71f907dedee968b5d0
+  ImageViewer.swift: 3debbc46f4f0b8187e7dac95bc5badc41626bb20
   SDWebImage: cf6922231e95550934da2ada0f20f2becf2ceba9
 
 PODFILE CHECKSUM: e724d0d4011b46b198571c9f9ed6734d40b74bc4
 
-COCOAPODS: 1.9.3
+COCOAPODS: 1.11.3

--- a/Sources/ImageViewer_swift/ImageViewerController.swift
+++ b/Sources/ImageViewer_swift/ImageViewerController.swift
@@ -71,8 +71,8 @@ UIGestureRecognizerDelegate {
         imageView.translatesAutoresizingMaskIntoConstraints = false
         top = imageView.topAnchor.constraint(equalTo: scrollView.topAnchor)
         leading = imageView.leadingAnchor.constraint(equalTo: scrollView.leadingAnchor)
-        trailing = scrollView.trailingAnchor.constraint(equalTo: imageView.trailingAnchor)
-        bottom = scrollView.bottomAnchor.constraint(equalTo: imageView.bottomAnchor)
+        trailing = imageView.trailingAnchor.constraint(equalTo: scrollView.trailingAnchor)
+        bottom = imageView.bottomAnchor.constraint(equalTo: scrollView.bottomAnchor)
         
         top.isActive = true
         leading.isActive = true


### PR DESCRIPTION
## 概要

- ImageViewerControllerの func loadView()において、
    - top, leadingは imageViewからの Anchorだったのに対し、
    - trailing, bottomは scrollViewからの Anchorだったので、
    - これを全て imageViewからの Anchorとした

## チェックリスト
- [x] ビルドが通るか
- [x] Demoアプリのメニュー「With URL」を選択し、表示された画像をタップした際、画像が中央に表示されるか
    - [ ] 特に、ホームボタンのない実機にて検証要